### PR TITLE
Fixed JUST_PARAMS_PATTERN regex

### DIFF
--- a/src/main/java/org/hisp/dhis/rules/RuleFunctionCall.java
+++ b/src/main/java/org/hisp/dhis/rules/RuleFunctionCall.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 @AutoValue
 abstract class RuleFunctionCall
 {
-        private static final Pattern JUST_PARAMS_PATTERN = Pattern.compile( "(^[^\\(]+\\()|\\)" );
+        private static final Pattern JUST_PARAMS_PATTERN = Pattern.compile( "(^[^\\(]+\\()|\\)$" );
 
         private static final Pattern SPLIT_PARAMS_PATTERN = Pattern.compile( "(('[^']+')|([^,]+))" );
 


### PR DESCRIPTION
JUST_PARAMS_PATTERN regex was not selecting all characters for the params if it had nested parenthesis